### PR TITLE
1.13.2 updates

### DIFF
--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/Main.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/Main.java
@@ -39,16 +39,22 @@ public class Main extends JavaPlugin {
         } else {
             ConfigurationSection compressibleConfig = config.getConfigurationSection("compressible");
 
+// This block was modified by @cindyker for The Minecats community, implimented by @AeSix
+// original cause for non-operation was invalid item names in the config. 
             this.getLogger().info(compressibleConfig.toString());
             for (Map.Entry<String, Object> entry : compressibleConfig.getValues(false).entrySet()) {
                 Material material = Material.valueOf(entry.getKey());
+// the next if-block will give a nice error message for any incorrect item names in the config
+                if(material == null){
+                       this.getLogger().info("Error in Config! Material: " + entry.getKey() + " is not a real material.");
+                       continue;  //Go to next item to check.  
+                }
                 Map<String, String> blockConfig = new HashMap<>();
                 blockConfig.put("name", config.getString("compressible." + entry.getKey() + ".name"));
                 blockConfig.put("lore", config.getString("compressible." + entry.getKey() + ".lore"));
                 blockConfig.put("texture", config.getString("compressible." + entry.getKey() + ".texture"));
                 blocksConfig.put(material, blockConfig);
             }
-
             // Initialize blocks & recipes
             RegisterBlocks.init(this);
             RegisterRecipes.init(this);

--- a/Plugin/src/main/resources/config.yml
+++ b/Plugin/src/main/resources/config.yml
@@ -44,7 +44,7 @@ compressible:
     lore: default
     texture: afb0375540965e555ceb156aa67b4e656a422c9dfe498e88f676ac1116fa8d
 
-  DARK_WOOD:
+  DARK_OAK_WOOD:
     name: default
     lore: default
     texture: 1b381cce56443bdf736cbd26c97919807fcf35548ad7f151db4d84218e6dc6b4
@@ -124,7 +124,7 @@ compressible:
     lore: default
     texture: 5d7a50f69638b5f9dbb18f2fb93e5ee5d922f9a3c5a50593bb64bba42bb31e
 
-  SOULSAND:
+  SOUL_SAND:
     name: default
     lore: default
     texture: 46fb3178630fc3a58e15944a8fc1cdcaf45965824d8b31ff66f88f024e64bc


### PR DESCRIPTION
Fixed config to use valid names for SOUL_SAND and DARK_OAK_WOOD
Added check in Main.java to give a nice error message if any item name in the config is not correct so it may be adjusted as needed. 