### PR TITLE
Fixes for restructure, Improve commands, Replace default name system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,12 +82,7 @@ fabric.properties
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-Supprimerait .gitignore
-Supprimerait CompressedBlocksPlugin.iml
-Supprimerait CompressedBlocksPlugin.ipr
-Supprimerait CompressedBlocksPlugin.iws
-Supprimerait out/
-Supprimerait api/
-!/lib/spigot-1.11.2-R0.1-SNAPSHOT.jar
+# Custom rules
+target/
+BuildTools/
+.idea/

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/Main.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/Main.java
@@ -10,12 +10,11 @@ import io.github.joffrey4.compressedblocks.util.VersionChecker;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.craftbukkit.v1_16_R2.inventory.CraftShapedRecipe;
+import org.bukkit.craftbukkit.v1_16_R2.inventory.CraftShapelessRecipe;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class Main extends JavaPlugin {
 
@@ -27,6 +26,8 @@ public class Main extends JavaPlugin {
     public void onEnable() {
         saveDefaultConfig();
 
+        blocksConfig = new HashMap<>();
+
         // Check is a new version exists
         VersionChecker.init(this);
 
@@ -35,37 +36,39 @@ public class Main extends JavaPlugin {
         if (nmsHandler == null) {
             this.getLogger().info("Disabling CompressedBlocks");
             this.setEnabled(false);
-
-        } else {
-            ConfigurationSection compressibleConfig = config.getConfigurationSection("compressible");
-
-// This block was modified by @cindyker for The Minecats community, implimented by @AeSix
-// original cause for non-operation was invalid item names in the config. 
-            this.getLogger().info(compressibleConfig.toString());
-            for (Map.Entry<String, Object> entry : compressibleConfig.getValues(false).entrySet()) {
-                Material material = Material.valueOf(entry.getKey());
-// the next if-block will give a nice error message for any incorrect item names in the config
-                if(material == null){
-                       this.getLogger().info("Error in Config! Material: " + entry.getKey() + " is not a real material.");
-                       continue;  //Go to next item to check.  
-                }
-                Map<String, String> blockConfig = new HashMap<>();
-                blockConfig.put("name", config.getString("compressible." + entry.getKey() + ".name"));
-                blockConfig.put("lore", config.getString("compressible." + entry.getKey() + ".lore"));
-                blockConfig.put("texture", config.getString("compressible." + entry.getKey() + ".texture"));
-                blocksConfig.put(material, blockConfig);
-            }
-            // Initialize blocks & recipes
-            RegisterBlocks.init(this);
-            RegisterRecipes.init(this);
-
-            // Initialize plugin mechanics
-            RegisterEvent.init(this, nmsHandler);
-
-            // Initialize commands
-            RegisterCommand.init(this);
-
+            return;
         }
+
+        ConfigurationSection compressibleConfig = config.getConfigurationSection("compressible");
+
+        // This block was modified by @cindyker for The Minecats community, implemented by @AeSix
+        // original cause for non-operation was invalid item names in the config.
+        this.getLogger().info(compressibleConfig.toString());
+        for (Map.Entry<String, Object> entry : compressibleConfig.getValues(false).entrySet()) {
+            Material material;
+
+            try {
+                material = Material.valueOf(entry.getKey());
+            } catch (Exception e) {
+                this.getLogger().severe("Error in Config! Material: " + entry.getKey() + " is not a real material.");
+                continue;  //Go to next item to check.
+            }
+            Map<String, String> blockConfig = new HashMap<>();
+            blockConfig.put("name", config.getString("compressible." + entry.getKey() + ".name"));
+            blockConfig.put("lore", config.getString("compressible." + entry.getKey() + ".lore"));
+            blockConfig.put("texture", config.getString("compressible." + entry.getKey() + ".texture"));
+            blocksConfig.put(material, blockConfig);
+        }
+
+        // Initialize blocks & recipes
+        RegisterBlocks.init(this);
+        RegisterRecipes.init(this);
+
+        // Initialize plugin mechanics
+        RegisterEvent.init(this, nmsHandler);
+
+        // Initialize commands
+        RegisterCommand.init(this);
     }
 
 

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/Main.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/Main.java
@@ -18,13 +18,14 @@ import java.util.*;
 
 public class Main extends JavaPlugin {
 
-    private FileConfiguration config = getConfig();
+    private FileConfiguration config;
     private static NMS nmsHandler;
     public static Map<Material, Map<String, String>> blocksConfig;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
+        config = getConfig();
 
         blocksConfig = new HashMap<>();
 

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/block/BlockCompressed.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/block/BlockCompressed.java
@@ -19,43 +19,43 @@ import java.util.UUID;
 public class BlockCompressed {
 
     private static Material material;
-    private static String displayname;
-    private static String name;
+    private static String displayName;
+    private static String materialName;
     private static String typeName;
     private static FileConfiguration config;
 
-    public BlockCompressed(Material material, String typeName, Main plugin) {
+    public BlockCompressed(Material material, Main plugin) {
         BlockCompressed.config = plugin.getConfig();
         BlockCompressed.material = material;
 
-        // Internal name of the compressed block (ex: oakwood)
-        BlockCompressed.name = setName(typeName);
+        // Name of the type of the block (ex: Oak_Wood)
+        BlockCompressed.typeName = material.toString();
 
         // Name of the compressed block item (ex: Compressed Oak Wood)
-        BlockCompressed.displayname = setDisplayName(typeName);
+        BlockCompressed.displayName = setDisplayName();
 
-        // Name of the type of the block (ex: Oak Wood)
-        BlockCompressed.typeName = typeName;
+        // Name of the compressed block material
+        BlockCompressed.materialName = setMaterialName();
     }
 
-    private String setName(String name) {
-        return name.replaceAll("\\s+","").toLowerCase();
-    }
+    private String setDisplayName() {
+        String displayName = config.getString("compressible." + typeName + ".name");
 
-    private String setDisplayName(String typeName) {
-        String displayName;
-
-        if (Objects.equals(config.getString(name + ".name"), "default")) {
-            displayName = config.getString("default.name");
-        } else {
-            displayName = config.getString(name + ".name");
-        }
-
-        if (displayName.contains("&type")) {
-            displayName = displayName.replace("&type", typeName);
+        if(displayName == null || displayName.isEmpty()) {
+            displayName = typeName;
         }
 
         return ChatColor.translateAlternateColorCodes('&', displayName);
+    }
+
+    private String setMaterialName() {
+        String materialName = config.getString("compressible." + typeName + ".material-name");
+
+        if(materialName == null || materialName.isEmpty()) {
+            materialName = typeName;
+        }
+
+        return ChatColor.translateAlternateColorCodes('&', materialName);
     }
 
     public ItemStack getItemStack() {
@@ -64,17 +64,18 @@ public class BlockCompressed {
         ItemStack skull = new ItemStack(Material.PLAYER_HEAD, 1);
 
         String skinURL = "http://textures.minecraft.net/texture/";
-        if (config.getString(name + ".texture").isEmpty()) {
+        String texture = config.getString("compressible." + typeName + ".texture");
+        if (texture == null || texture.isEmpty()) {
             return skull;
         } else {
-            skinURL += config.getString(name + ".texture");
+            skinURL += config.getString("compressible." + typeName + ".texture");
         }
 
         // Get the skull metadata and initialize a texture profile
         SkullMeta skullMeta = (SkullMeta) skull.getItemMeta();
         GameProfile profile = new GameProfile(UUID.fromString("069a79f4-44e9-4726-a5be-fca90e38aaf5"), null);
         profile.getProperties().put("textures", new Property("textures", Base64Coder.encodeString("{textures:{SKIN:{url:\"" + skinURL + "\"}}}")));
-        profile.getProperties().put("compBlocksName", new Property("compBlocksName", name));
+        profile.getProperties().put("compBlocksName", new Property("compBlocksName", typeName));
 
         // Set the texture profile to the skull metadata
         Field profileField;
@@ -92,23 +93,23 @@ public class BlockCompressed {
     }
 
     public String getDisplayName() {
-        return displayname;
+        return displayName;
     }
 
     public List<String> getLore() {
         List<String> lore;
 
-        if (Objects.equals(config.getString(name + ".lore"), "default")) {
+        if (Objects.equals(config.getString("compressible." + typeName + ".lore"), "default")) {
             lore = config.getStringList("default.lore");
         } else {
-            lore = config.getStringList(name + ".lore");
+            lore = config.getStringList("compressible." + typeName + ".lore");
         }
 
         for (final ListIterator<String> i = lore.listIterator(); i.hasNext();) {
             String line = i.next();
 
             if (line.contains("&type")) {
-                line = line.replace("&type", typeName);
+                line = line.replace("&type", materialName);
             }
             i.set(ChatColor.translateAlternateColorCodes('&', line));
         }

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/block/RegisterBlocks.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/block/RegisterBlocks.java
@@ -43,7 +43,11 @@ public class RegisterBlocks {
 
 
     public static ItemStack getByName(String name) {
-        return RegisterBlocks.registeredBlocks.get(Material.valueOf(name));
+        try {
+            return RegisterBlocks.registeredBlocks.get(Material.valueOf(name));
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     public static ItemStack getCompressedBlock(String name, Player player) {

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/block/RegisterBlocks.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/block/RegisterBlocks.java
@@ -21,9 +21,7 @@ public class RegisterBlocks {
 
         for (Map.Entry<Material, Map<String, String>> block : Main.blocksConfig.entrySet()) {
             Material material = block.getKey();
-            Map<String, String> blockConfig = block.getValue();
-            String name = blockConfig.get("name");
-            ItemStack compressedBlock = register(new BlockCompressed(material, name, plugin));
+            ItemStack compressedBlock = register(new BlockCompressed(material, plugin));
             registeredBlocks.put(material, compressedBlock);
         }
     }

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/block/RegisterBlocks.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/block/RegisterBlocks.java
@@ -15,6 +15,10 @@ public class RegisterBlocks {
     public static Map<Material, ItemStack> registeredBlocks;
 
     public static void init(Main plugin) {
+        if (registeredBlocks == null) {
+            registeredBlocks = new HashMap<>();
+        }
+
         for (Map.Entry<Material, Map<String, String>> block : Main.blocksConfig.entrySet()) {
             Material material = block.getKey();
             Map<String, String> blockConfig = block.getValue();

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/command/CommandGive.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/command/CommandGive.java
@@ -27,38 +27,50 @@ public class CommandGive {
 
             // Check if the targeted player exists, and if the required block exists
             Player target = Bukkit.getServer().getPlayer(strings[1]);
-            if (target != null && RegisterBlocks.getByName(strings[2]) != null) {
 
-                // Check the if the third parameter exists as positive int
-                int amount = 1;
-                if (strings.length == 4) {
-                    try {
-                        amount = Integer.parseInt(strings[3]);
-                        if (amount <= 0) {
-                            amount = 1;
-                        } else if (amount > 2304) {
-                            amount = 2304;
-                        }
-                    } catch (NumberFormatException ignored) {}
-                }
-
-                // Give the block and send notifications
-
-                ItemStack item = RegisterBlocks.getCompressedBlock(strings[2], null);
-                item.setAmount(amount);
-                target.getInventory().addItem(item);
-
-                // Send messages to sender and receiver
-                String message = ChatColor.translateAlternateColorCodes('&', "%s " + amount + "x" + item.getItemMeta().getDisplayName() + "&r %s &7&o" + target.getDisplayName());
-                if (commandSender instanceof Player && commandSender == target) {
-                    target.sendMessage(String.format(message, "Receive", "from"));
-                } else {
-                    commandSender.sendMessage(String.format(message, "Give", "to"));
-                    target.sendMessage(String.format(message, "Receive", "from"));
-                }
-                return true;
+            if(target == null) {
+                String message = ChatColor.translateAlternateColorCodes('&', "&4Invalid Target Specified");
+                commandSender.sendMessage(message);
+                return false;
             }
-            commandSender.sendMessage("Invalid player or block name.");
+
+            String cleanedMaterialName = strings[2].toUpperCase();
+            ItemStack stack = RegisterBlocks.getByName(cleanedMaterialName);
+
+            if(stack == null) {
+                String message = ChatColor.translateAlternateColorCodes('&', "&4Invalid Material");
+                commandSender.sendMessage(message);
+                return false;
+            }
+
+            // Check the if the third parameter exists as positive int
+            int amount = 1;
+            if (strings.length == 4) {
+                try {
+                    amount = Integer.parseInt(strings[3]);
+                    if (amount <= 0) {
+                        amount = 1;
+                    } else if (amount > 2304) {
+                        amount = 2304;
+                    }
+                } catch (NumberFormatException ignored) {}
+            }
+
+            // Give the block and send notifications
+
+            ItemStack item = RegisterBlocks.getCompressedBlock(cleanedMaterialName, target);
+            item.setAmount(amount);
+            target.getInventory().addItem(item);
+
+            // Send messages to sender and receiver
+            String message = ChatColor.translateAlternateColorCodes('&', "%s " + amount + "x" + item.getItemMeta().getDisplayName() + "&r %s &7&o" + target.getDisplayName());
+            if (commandSender instanceof Player && commandSender == target) {
+                target.sendMessage(String.format(message, "Receive", "from"));
+            } else {
+                commandSender.sendMessage(String.format(message, "Give", "to"));
+                target.sendMessage(String.format(message, "Receive", "from"));
+            }
+            return true;
         }
         commandSender.sendMessage("Missing parameters:");
         return false;

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/event/EventBase.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/event/EventBase.java
@@ -44,6 +44,10 @@ public class EventBase {
                     return false;
                 }
 
+                if (profile == null) {
+                    return false;
+                }
+
                 return profile.getProperties().containsKey("compBlocksName");
             }
         }

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/event/EventOnBreak.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/event/EventOnBreak.java
@@ -15,12 +15,10 @@ import org.bukkit.inventory.ItemStack;
 
 public class EventOnBreak extends EventBase implements Listener {
 
-    private FileConfiguration config;
     private NMS nmsHandler;
 
     public EventOnBreak(Main plugin, NMS nmsHandler) {
         super(plugin);
-        this.config = plugin.getConfig();
         this.nmsHandler = nmsHandler;
     }
 
@@ -30,14 +28,13 @@ public class EventOnBreak extends EventBase implements Listener {
      */
     @EventHandler
     public void onBreak (BlockBreakEvent event) {
-
         ImmutableTriple breakResult = nmsHandler.eventOnBreak(event);
         if ((Boolean) breakResult.getLeft()) {
 
             // Reset the block to AIR to avoid it to drop anything
             event.getBlock().setType(Material.AIR);
 
-            ItemStack dropStack = RegisterBlocks.getUnCompressedBlocks((String) breakResult.getRight(), null);
+            ItemStack dropStack = RegisterBlocks.getUnCompressedBlocks((String) breakResult.getRight(), event.getPlayer());
             event.getBlock().getWorld().dropItemNaturally((Location) breakResult.getMiddle(), dropStack);
         }
     }

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/event/EventOnCraft.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/event/EventOnCraft.java
@@ -92,6 +92,7 @@ public class EventOnCraft extends EventBase implements Listener {
         try {
             profile = getProfile(skullMeta);
         } catch (ProfileNotFoundException e) {
+            e.printStackTrace();
             return new ItemStack(Material.AIR);
         }
 
@@ -111,6 +112,7 @@ public class EventOnCraft extends EventBase implements Listener {
         try {
             profile = getProfile(skullMeta);
         } catch (ProfileNotFoundException e) {
+            e.printStackTrace();
             return new ItemStack(Material.AIR);
         }
 

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/recipe/RegisterRecipes.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/recipe/RegisterRecipes.java
@@ -15,14 +15,18 @@ import java.util.Map;
 public class RegisterRecipes {
 
     public static void init(Main plugin) {
-        NamespacedKey namespacedKey = new NamespacedKey(plugin, "receipes");
-
         Server server = Bukkit.getServer();
 
         for (Map.Entry<Material, ItemStack> registeredBlock : RegisterBlocks.registeredBlocks.entrySet()) {
             Material rawMaterial = registeredBlock.getKey();
+
+            NamespacedKey namespacedKey;
+
+            namespacedKey = new NamespacedKey(plugin, rawMaterial.name() + "-compressed");
             ItemStack compressedBlock = registeredBlock.getValue();
             server.addRecipe(Compressing(namespacedKey, compressedBlock, rawMaterial));
+
+            namespacedKey = new NamespacedKey(plugin, rawMaterial.name() + "-uncompressed");
             server.addRecipe(UnCompressing(namespacedKey, new ItemStack(rawMaterial), compressedBlock.getType()));
         }
     }

--- a/Plugin/src/main/resources/config.yml
+++ b/Plugin/src/main/resources/config.yml
@@ -13,123 +13,145 @@
 # Colors supported. &type is replaced by the block type (ex: Stone, Oak Wood, ...).
 
 default:
-  name: '&6Compressed &type'
   lore:
-    - 'A block that contain'
+    - 'A block that contains'
     - '9x &type !'
 
 compressible:
   OAK_WOOD:
-    name: default
+    name: '&6Compressed Oak Wood'
+    material-name: 'Oak Wood'
     lore: default
     texture: b79bd6534a7d9def47aa7ccc52b330f454520eb18dbaf6959ff1ba8f4c03
 
   SPRUCE_WOOD:
-    name: default
+    name: '&6Compressed Spruce Wood'
+    material-name: 'Spruce Wood'
     lore: default
     texture: c1a3ea81b18cd5891fadfae2f91407173d83cea23d62a21d7236ab36a2eba
 
   BIRCH_WOOD:
-    name: default
+    name: '&6Compressed Birch Wood'
+    material-name: 'Birch Wood'
     lore: default
     texture: d2521df5fe65b4b57b7ce5eb4d057fb406351dda1ce64e984e14ee0fd52f8c7
 
   JUNGLE_WOOD:
-    name: default
+    name: '&6Compressed Jungle Wood'
+    material-name: 'Jungle Wood'
     lore: default
     texture: 9abf47a92f40451a32aac2e3f0a577edfc65d33d3e557995c94b318fe1e61
 
   ACACIA_WOOD:
-    name: default
+    name: '&6Compressed Acacia Wood'
+    material-name: 'Acacia Wood'
     lore: default
     texture: afb0375540965e555ceb156aa67b4e656a422c9dfe498e88f676ac1116fa8d
 
   DARK_OAK_WOOD:
-    name: default
+    name: '&6Compressed Dark Oak Wood'
+    material-name: 'Dark Oak Wood'
     lore: default
     texture: 1b381cce56443bdf736cbd26c97919807fcf35548ad7f151db4d84218e6dc6b4
 
   OAK_PLANKS:
-    name: default
+    name: '&6Compressed Oak Planks'
+    material-name: 'Oak Planks'
     lore: default
     texture: 3e31d0901888cbe6e97f90cf51a3bdd4ced79d3c1ef66397a031198f6d298b22
 
   SPRUCE_PLANKS:
-    name: default
+    name: '&6Compressed Spruce Planks'
+    material-name: 'Spruce Planks'
     lore: default
     texture: b15a81bf3a1908df82b4a48bf03723127d095716e9ee885d79bac35bedbae
 
   BIRCH_PLANKS:
-    name: default
+    name: '&6Compressed Birch Planks'
+    material-name: 'Birch Planks'
     lore: default
     texture: 784ce9ab5e32810becc5f5f489f4da138db484887faf67342440614549af36
 
   JUNGLE_PLANKS:
-    name: default
+    name: '&6Compressed Jungle Planks'
+    material-name: 'Jungle Planks'
     lore: default
     texture: 5d84868a9c8c4994fb61a970c44ccd13296d3fd68067c7f3e8b7f7b0d2d838bb
 
   ACACIA_PLANKS:
-    name: default
+    name: '&6Compressed Acacia Planks'
+    material-name: 'Acacia Planks'
     lore: default
     texture: fb497bd15763e1e9325d58ce62687dd771322c5f8cd9996f5eb32a3ea052ef66
 
   DARK_OAK_PLANKS:
-    name: default
+    name: '&6Compressed Dark Oak Planks '
+    material-name: 'Dark Oak Planks '
     lore: default
     texture: 2e48fefb5ef4ae56c95a99ae7d032d13bef49ca0cdfa87fe9b1b179d2ba0
 
   GRAVEL:
-    name: default
+    name: '&6Compressed Gravel'
+    material-: 'Gravel'
     lore: default
     texture: 6e6c59ee744f3cfbe9b71e57a8b53f1e3ea0b1beb7c4e3fec7e7623b8e1c8
 
   SAND:
-    name: default
+    name: '&6Compressed Sand'
+    material-name: 'Sand'
     lore: default
     texture: d68995bb9d761a6df03d4f69db535383571323fb541457ec42b3ec62c0fbc8
 
   RED_SAND:
-    name: default
+    name: '&6Compressed Red Sand'
+    material-name: 'Red Sand'
     lore: default
     texture: e2143b9675bbb879ef3f83773fc4e279dbb4ee4dcf8fd32746e2da218998327
 
   STONE:
-    name: default
+    name: '&6Compressed Stone'
+    material-name: 'Stone'
     lore: default
     texture: f7ff2859d4719f9145a2a1d8b019a47bd26f7c812fba3333666868f1019b9e6
 
   GRANITE:
-    name: default
+    name: '&6Compressed Granite'
+    material-name: 'Granite'
     lore: default
     texture: 7e32d31edf8cfd9e29fd934d9a381c72398c03fbd37155034a658814b93573
 
   DIORITE:
-    name: default
+    name: '&6Compressed Diorite'
+    material-name: 'Diorite'
     lore: default
     texture: eac080f897dcbc76d14172f61a318b381fee8ca0495aada76aceac3de218c742
 
   ANDESITE:
-    name: default
+    name: '&6Compressed Andesite'
+    material-name: 'Andesite'
     lore: default
     texture: c15fa0d74b34425b3d6217d5c9b9528dbc885d353faa8d02e680cd78b886
 
   DIRT:
-    name: default
+    name: '&6Compressed Dirt'
+    material-name: 'Dirt'
     lore: default
     texture: 21a1e1916ccd5c3716bf82585b83ddd1be5fe087a14c6341c76db51ea2ed583
 
   COBBLESTONE:
-    name: default
+    name: '&6Compressed CobbleStone'
+    material-name: 'CobbleStone'
     lore: default
     texture: 5d7a50f69638b5f9dbb18f2fb93e5ee5d922f9a3c5a50593bb64bba42bb31e
 
   SOUL_SAND:
-    name: default
+    name: '&6Compressed Soul Sand'
+    material-name: 'Soul Sand'
     lore: default
     texture: 46fb3178630fc3a58e15944a8fc1cdcaf45965824d8b31ff66f88f024e64bc
 
   NETHERRACK:
-    name: default
+    name: '&6Compressed Netherrack'
+    material-name: 'Netherrack'
     lore: default
     texture: a9c4791edd24634137e0b191dc68e4337bceb5a3b3bc08f264a8447ee69b27a

--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Doc and download: https://cbp.jbvn.me
 Bukkit page: https://dev.bukkit.org/projects/compressed-blocks-plugin
 
 Spigot page: https://www.spigotmc.org/resources/compressed-blocks-plugin.41308/
+
+## Building Required Server Jars
+
+To build this plugin you will need to run the `compileApiJars.bat` script, due to the fact spigot no longer posts built server images. It will clone down the buildtools.jar from spigot and build and install for each version required.

--- a/compileApiJars.bat
+++ b/compileApiJars.bat
@@ -1,0 +1,13 @@
+@echo off
+IF NOT EXIST BuildTools (
+    mkdir BuildTools
+)
+cd BuildTools
+curl -o BuildTools.jar https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
+
+echo "Running v1.13.2 build"
+java -jar BuildTools.jar --rev 1.13.2
+
+echo "Installing v1.13.2 locally"
+cmd /c mvn -B install:install-file -Dfile=spigot-1.13.jar -DgroupId=org.spigotmc -DartifactId=spigot -Dversion=1.13.2-R0.1-SNAPSHOT -Dpackaging=jar
+pause


### PR DESCRIPTION
I am unsure if this fork is still used but I wanted to get things working under 1.16.3 so I went through the adjustments required to make things work like before the code was restructured. The 1.13 api is still targeted so on newer spigot versions legacy material support has to load. This causes a hitch on crafting or breaking the first compressed block each server start.