### PR TITLE
Remove old imports, Add support for 1.16.3

### DIFF
--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -34,6 +34,14 @@
         </dependency>
         <dependency>
             <groupId>io.github.joffrey4.compressedblocks</groupId>
+            <artifactId>CompressedBlocksPlugin-v1_16_R2</artifactId>
+            <version>v1_16_R2</version>
+            <type>jar</type>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.github.joffrey4.compressedblocks</groupId>
             <artifactId>CompressedBlocksPlugin-api</artifactId>
             <version>API</version>
             <type>jar</type>
@@ -44,6 +52,14 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
             <version>1.13.2-R0.1-SNAPSHOT</version>
+            <type>jar</type>
+            <scope>provided</scope> <!-- The 'provided' scope will NOT get shaded in -->
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope> <!-- The 'provided' scope will NOT get shaded in -->
             <optional>true</optional>

--- a/Plugin/src/main/java/io/github/joffrey4/compressedblocks/Main.java
+++ b/Plugin/src/main/java/io/github/joffrey4/compressedblocks/Main.java
@@ -10,8 +10,6 @@ import io.github.joffrey4.compressedblocks.util.VersionChecker;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.craftbukkit.v1_16_R2.inventory.CraftShapedRecipe;
-import org.bukkit.craftbukkit.v1_16_R2.inventory.CraftShapelessRecipe;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.*;

--- a/compileApiJars.bat
+++ b/compileApiJars.bat
@@ -9,5 +9,14 @@ echo "Running v1.13.2 build"
 java -jar BuildTools.jar --rev 1.13.2
 
 echo "Installing v1.13.2 locally"
-cmd /c mvn -B install:install-file -Dfile=spigot-1.13.jar -DgroupId=org.spigotmc -DartifactId=spigot -Dversion=1.13.2-R0.1-SNAPSHOT -Dpackaging=jar
+cmd /c mvn -B install:install-file -Dfile=spigot-1.13.2.jar -DgroupId=org.spigotmc -DartifactId=spigot -Dversion=1.13.2-R0.1-SNAPSHOT -Dpackaging=jar
+
+pause
+
+echo "Running v1.16.5 build"
+java -jar BuildTools.jar --rev 1.16.5
+
+echo "Installing v1.16.5 locally"
+cmd /c mvn -B install:install-file -Dfile=spigot-1.16.5.jar -DgroupId=org.spigotmc -DartifactId=spigot -Dversion=1.16.5-R0.1-SNAPSHOT -Dpackaging=jar
+
 pause

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <modules>
         <module>API</module>
         <module>v1_13_R2</module>
+        <module>v1_16_R2</module>
         <module>Plugin</module>
     </modules>
 

--- a/v1_16_R2/pom.xml
+++ b/v1_16_R2/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.joffrey4.compressedblocks</groupId>
+    <artifactId>CompressedBlocksPlugin-v1_16_R2</artifactId>
+    <packaging>jar</packaging>
+    <name>CompressedBlocksPlugin implementation v1_16_R2</name>
+    <version>v1_16_R2</version>
+
+    <parent>
+        <groupId>io.github.joffrey4.compressedblocks</groupId>
+        <artifactId>CompressedBlocksPlugin-parent</artifactId>
+        <version>parent</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <type>jar</type>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.github.joffrey4.compressedblocks</groupId>
+            <artifactId>CompressedBlocksPlugin-api</artifactId> <!-- Depend on the API! -->
+            <version>API</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/v1_16_R2/src/main/java/io/github/joffrey4/compressedblocks/nms/v1_16_R2/NMSHandler.java
+++ b/v1_16_R2/src/main/java/io/github/joffrey4/compressedblocks/nms/v1_16_R2/NMSHandler.java
@@ -1,0 +1,54 @@
+package io.github.joffrey4.compressedblocks.nms.v1_16_R2;
+
+import com.mojang.authlib.GameProfile;
+import io.github.joffrey4.compressedblocks.api.NMS;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.BlockState;
+import org.bukkit.craftbukkit.v1_16_R3.block.CraftBlockEntityState;
+import org.bukkit.craftbukkit.v1_16_R3.block.CraftSkull;
+import net.minecraft.server.v1_16_R3.TileEntity;
+import org.bukkit.event.block.BlockBreakEvent;
+
+import java.lang.reflect.Field;
+
+public class NMSHandler implements NMS {
+    public <T extends TileEntity> T getTE(CraftBlockEntityState<T> cbs) {
+        try {
+            Field f = CraftBlockEntityState.class.getDeclaredField("tileEntity");
+            f.setAccessible(true);
+            return (T) f.get(cbs);
+        }
+        catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+
+    @Override
+    public ImmutableTriple<Boolean, Location, String> eventOnBreak (BlockBreakEvent event) {
+        BlockState block = event.getBlock().getState();
+
+        // Check if the block is an instance of Player Skull
+        if (block.getData().getItemType() == Material.LEGACY_SKULL_ITEM || block.getData().getItemType() == Material.PLAYER_HEAD) {
+            CraftSkull skull = (CraftSkull) block;
+            GameProfile skullProfile = getTE(skull).gameProfile;
+
+            // Check if the skull is a compressed block
+            if (skullProfile != null && skullProfile.getProperties().containsKey("compBlocksName")) {
+
+                // Drop a stack of the uncompressed blocks
+                Location location = event.getBlock().getLocation().add(0.5F, 0.5F, 0.5F);
+                String dropTypeName = skullProfile.getProperties().get("compBlocksName").iterator().next().getValue();
+
+                return new ImmutableTriple<>(true, location, dropTypeName);
+            }
+        }
+        return new ImmutableTriple<>(false, null, null);
+    }
+}


### PR DESCRIPTION
It appears I made this addition a while back but managed to leave it out of the original, this also corrects unused imports in Main.java that caused compilation failures.